### PR TITLE
Require Cabal 1.8+

### DIFF
--- a/bytestring-progress.cabal
+++ b/bytestring-progress.cabal
@@ -1,7 +1,7 @@
 Name: bytestring-progress
 Version: 1.4
 Build-Type: Simple
-Cabal-Version: >= 1.6
+Cabal-Version: >= 1.8
 License: BSD3
 License-File: LICENSE
 Author: Adam Wick <awick@uhsure.com>


### PR DESCRIPTION
Fixes the following warning:

```
Warning: bytestring-progress.cabal:32:51: version operators used. To use
version operators the package needs to specify at least 'cabal-version: >=
1.8'.
```